### PR TITLE
Endpoint escapes

### DIFF
--- a/pkg/catalog/template.go
+++ b/pkg/catalog/template.go
@@ -103,7 +103,7 @@ const NewPackageTemplate = `
 {{if eq (hasPattern $e.Attrs "ignore") false}}
 
 
-### {{$appName}} {{SanitiseOutputName $e.Name}}
+### {{$appName}} {{$e.Name}}
 {{Attribute $e "description"}}
 
 <details>

--- a/pkg/catalog/template.go
+++ b/pkg/catalog/template.go
@@ -103,7 +103,7 @@ const NewPackageTemplate = `
 {{if eq (hasPattern $e.Attrs "ignore") false}}
 
 
-### {{$appName}} {{$e.Name}}
+### <a name={{$appName}}-{{SanitiseOutputName $e.Name}}></a>{{$appName}} {{$e.Name}}
 {{Attribute $e "description"}}
 
 <details>


### PR DESCRIPTION
Endpoints are now not escaped in titles and hyperlinks in applications indexes work