### PR TITLE
Hide redoc link for remote imports

### DIFF
--- a/pkg/catalog/diagram.go
+++ b/pkg/catalog/diagram.go
@@ -262,7 +262,7 @@ func CreateFileName(dir string, elems ...string) (string, string) {
 
 // CreateRedoc registers a file that needs to be created when the input source context has extension .json or .yaml
 func (p *Generator) CreateRedoc(sourceContext *sysl.SourceContext, appName string) string {
-	if !IsOpenAPIFile(sourceContext) || !p.Redoc {
+	if !IsOpenAPIFile(sourceContext) || !p.Redoc || strings.Contains(sourceContext.GetFile(), "github") {
 		return ""
 	}
 	absPath, _ := CreateFileName(p.CurrentDir, appName+".redoc.html")

--- a/pkg/catalog/diagram_test.go
+++ b/pkg/catalog/diagram_test.go
@@ -171,3 +171,15 @@ func TestCreateRedocFlagFalse(t *testing.T) {
 	link := gen.CreateRedoc(sourceContext, appName)
 	assert.Equal(t, "", link)
 }
+
+func TestCreateRedocFromImportRemote(t *testing.T) {
+	appName := "myAppName"
+	fileName := "github.com/myorg/myrepo/specs/myfile.yaml"
+	sourceContext := &sysl.SourceContext{File: fileName}
+	gen := Generator{
+		RedocFilesToCreate: make(map[string]string),
+		Redoc:              true,
+	}
+	link := gen.CreateRedoc(sourceContext, appName)
+	assert.Equal(t, "", link)
+}


### PR DESCRIPTION
Currently, Redoc links are not supported for specifications hosted in other repos. This hides the links for applications which are imported from other repositories via Sysl Modules