### PR TITLE
Update to allow for pretty_package_name to be used

### DIFF
--- a/pkg/catalog/diagram.go
+++ b/pkg/catalog/diagram.go
@@ -399,7 +399,7 @@ func (p *Generator) ModuleAsMacroPackage(m *sysl.Module) map[string]*sysl.Module
 	_, includedProjects := p.getProjectApp(m)
 	for _, key := range SortedKeys(m.GetApps()) {
 		app := m.GetApps()[key]
-		packageName := Attribute(app, "package")
+		packageName := GetPackageName(p.RootModule, app)
 		if packageName == "" {
 			packageName = key
 		}
@@ -471,13 +471,14 @@ func (p *Generator) ModuleAsPackages(m *sysl.Module) map[string]*sysl.Module {
 	_, includedProjects := p.getProjectApp(m)
 	for _, key := range SortedKeys(m.GetApps()) {
 		app := m.GetApps()[key]
-		packageName := Attribute(app, "package")
+		packageName, _ := GetAppPackageName(app)
 		if packageName == "" {
 			packageName = key
 		}
 		if _, ok := includedProjects[packageName]; len(includedProjects) > 0 && !ok {
 			continue
 		}
+		packageName = GetPackageName(p.RootModule, app)
 		if syslutil.HasPattern(app.GetAttrs(), "ignore") || syslutil.HasPattern(app.GetAttrs(), "project") {
 			continue
 		}

--- a/pkg/catalog/generator.go
+++ b/pkg/catalog/generator.go
@@ -48,6 +48,7 @@ type Generator struct {
 	PlantumlService      string
 	Templates            []*template.Template
 	StartTemplateIndex   int
+	FilterPackage        []string // Filter these regex terms out of packagenames
 
 	CustomTemplate bool
 	LiveReload     bool // Add live reload javascript to html

--- a/pkg/catalog/generator_test.go
+++ b/pkg/catalog/generator_test.go
@@ -121,3 +121,28 @@ func TestHandleSourceURL(t *testing.T) {
 		handleSourceURL("github.com/invalid/path"),
 	)
 }
+
+func TestPrettyPackageNmes(t *testing.T) {
+	contents := `
+AppName:
+	@package = "whatever"
+whatever:
+	@pretty_package_name = "renamed"
+`
+	outputDir := "docs"
+	fs := afero.NewMemMapFs()
+	logger := logrus.New()
+	m, err := parse.NewParser().ParseString(contents)
+	if err != nil {
+		log.Fatal(err)
+	}
+	p := NewProject("", plantumlService, "markdown", logger, m, fs, outputDir)
+	p.SetOptions(false, false, false, true, false, "", "")
+	p.Run()
+	// Assert the right files exist
+	testFile := outputDir + "/renamed/README.md"
+	_, err = fs.Open(testFile)
+	assert.NoError(t, err)
+	_, err = afero.ReadFile(fs, testFile)
+	assert.NoError(t, err)
+}

--- a/pkg/catalog/generator_test.go
+++ b/pkg/catalog/generator_test.go
@@ -127,7 +127,7 @@ func TestPrettyPackageNmes(t *testing.T) {
 AppName:
 	@package = "whatever"
 whatever:
-	@pretty_package_name = "renamed"
+	@package_alias = "renamed"
 `
 	outputDir := "docs"
 	fs := afero.NewMemMapFs()

--- a/pkg/catalog/util.go
+++ b/pkg/catalog/util.go
@@ -196,7 +196,7 @@ func GetAppPackageName(a Namer) (string, string) {
 func GetPackageName(m *sysl.Module, a Namer) string {
 	packageName, _ := GetAppPackageName(a)
 	pkg := m.Apps[packageName]
-	if attr := pkg.GetAttrs()["pretty_package_name"]; attr != nil {
+	if attr := pkg.GetAttrs()["package_alias"]; attr != nil {
 		return attr.GetS()
 	}
 	return packageName

--- a/pkg/catalog/util.go
+++ b/pkg/catalog/util.go
@@ -193,11 +193,20 @@ func GetAppPackageName(a Namer) (string, string) {
 	return packageName, appName
 }
 
+func GetPackageName(m *sysl.Module, a Namer) string {
+	packageName, _ := GetAppPackageName(a)
+	pkg := m.Apps[packageName]
+	if attr := pkg.GetAttrs()["pretty_package_name"]; attr != nil {
+		return attr.GetS()
+	}
+	return packageName
+
+}
+
 func ModulePackageName(m *sysl.Module) string {
 	for _, key := range SortedKeys(m.GetApps()) {
 		app := m.Apps[key]
-		packageName, _ := GetAppPackageName(app)
-		return packageName
+		return GetPackageName(m, app)
 	}
 	return ""
 }


### PR DESCRIPTION
Adds ability to rename the packages:
```
AppName:
	@package = "whatever"
whatever:
	@pretty_package_name = "renamed"
```
in this example the generated directory will be `renamed`, not `whatever` 