### PR TITLE
regenerate docs and push it to master in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,20 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
       with:
         persist-credentials: false
         fetch-depth: 0
     - name: Gen Docs
+      if: "!contains(github.event.head_commit.message, 'skip-ci')"
       run: make docker-compose
     - name: Commit files
       run: |
         git config --local user.email "syslbot@anz.com"
         git config --local user.name "SyslBot"
         git add .
-        git commit -m "Regenerate docs" && echo ::set-env name=can_push::1 || echo "No changes to docs"
+        git commit -m "Regenerate docs [skip-ci]" && echo ::set-env name=can_push::1 || echo "No changes to docs"
     - name: Push changes
       if: env.can_push == 1
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v0.6
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,15 +8,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@master
+      with:
+        persist-credentials: false
+        fetch-depth: 0
     - name: Gen Docs
       run: make docker-compose
-    - name: Create Pull Request
-      if: "!contains(github.event.head_commit.message, 'skip ci')"
-      uses: peter-evans/create-pull-request@v2
+    - name: Commit files
+      run: |
+        git config --local user.email "syslbot@anz.com"
+        git config --local user.name "SyslBot"
+        git add .
+        git commit -m "Regenerate docs" && echo ::set-env name=can_push::1 || echo "No changes to docs"
+    - name: Push changes
+      if: env.can_push == 1
+      uses: ad-m/github-push-action@master
       with:
-        commit-message: "Update docs [skip-ci]"
-        title: "Update docs [skip-ci]"
-        branch-suffix: random
-
-          
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes proposed in this pull request:
Regenerating docs and push it to master in CI, instead of creating PR.
- There's no harm generating wrong examples
- The auto-generated PRs keep been forgotten
