### PR TITLE
Refactor generated Redoc to reference served file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,10 @@ sysl-catalog -o demo/markdown demo/sizzle.sysl
 sysl-catalog --type=html --plantuml=https://plantuml.com/plantuml --embed -o demo/html demo/sizzle.sysl --redoc
 mkdir -p docs
 cp -r demo/html/* docs
+mkdir demo/html/demo/
+mkdir docs/demo/
+cp demo/mastercard.yaml demo/html/demo/mastercard.yaml
+cp demo/mastercard.yaml docs/demo/mastercard.yaml
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
  sed -i "s/sizzle.sysl/<a href=http:\/\/github.com\/anz-bank\/sysl-catalog>This is an example of sysl catalog deployed to github pages <\/a>/" docs/index.html

--- a/pkg/catalog/diagram.go
+++ b/pkg/catalog/diagram.go
@@ -288,7 +288,7 @@ func CreateFileName(dir string, elems ...string) (string, string) {
 
 // CreateRedoc registers a file that needs to be created when the input source context has extension .json or .yaml
 func (p *Generator) CreateRedoc(sourceContext *sysl.SourceContext, appName string) string {
-	if !IsOpenAPIFile(sourceContext) || !p.Redoc || strings.Contains(sourceContext.GetFile(), "github") {
+	if !IsOpenAPIFile(sourceContext) || !p.Redoc {
 		return ""
 	}
 	absPath, _ := CreateFileName(p.CurrentDir, appName+".redoc.html")

--- a/pkg/catalog/diagram_test.go
+++ b/pkg/catalog/diagram_test.go
@@ -225,7 +225,7 @@ func TestCreateReturnDataModelWithEmpty(t *testing.T) {
 }
 func TestCreateRedoc(t *testing.T) {
 	appName := "myAppName"
-	fileName := "myfile.yaml"
+	fileName := "sysl/myfile.yaml"
 	sourceContext := &sysl.SourceContext{File: fileName}
 	gen := Generator{
 		CurrentDir:         "myAppName",
@@ -236,7 +236,7 @@ func TestCreateRedoc(t *testing.T) {
 	t.Log(gen.RedocFilesToCreate)
 	registeredFile, ok := gen.RedocFilesToCreate["myAppName/myappname.redoc.html"]
 	assert.True(t, ok)
-	assert.Equal(t, "https://raw.githubusercontent.com/anz-bank/sysl-catalog/master/myfile.yaml", registeredFile)
+	assert.Equal(t, "/sysl/myfile.yaml", registeredFile)
 	assert.Equal(t, "myappname.redoc.html", link)
 }
 
@@ -261,5 +261,5 @@ func TestCreateRedocFromImportRemote(t *testing.T) {
 		Redoc:              true,
 	}
 	link := gen.CreateRedoc(sourceContext, appName)
-	assert.Equal(t, "", link)
+	assert.Equal(t, "myappname.redoc.html", link)
 }

--- a/pkg/catalog/spec.go
+++ b/pkg/catalog/spec.go
@@ -22,12 +22,7 @@ func IsOpenAPIFile(source *sysl.SourceContext) bool {
 // BuildSpecURL takes a source context reference and builds an raw git URL for it
 // It handles sourceContext paths which are from remote repos as well as in the same repo
 func BuildSpecURL(source *sysl.SourceContext) (string, error) {
-	repoURL, err := GetRemoteFromGit()
-	if err != nil {
-		return "", err
-	}
-	rawRepoURL := BuildGithubRawURL(repoURL)
-	return rawRepoURL + source.GetFile(), nil
+	return "/" + source.GetFile(), nil
 }
 
 // GetRemoteFromGit gets the URL to the git remote

--- a/pkg/catalog/spec_test.go
+++ b/pkg/catalog/spec_test.go
@@ -21,6 +21,13 @@ func TestIsOpenAPIFileYAML(t *testing.T) {
 	assert.True(t, result)
 }
 
+func TestIsOpenAPIFileYAMLOAS(t *testing.T) {
+	t.Parallel()
+	sourceContext := &sysl.SourceContext{File: "github.com/myorg/test/spec.oas.yaml"}
+	result := IsOpenAPIFile(sourceContext)
+	assert.True(t, result)
+}
+
 func TestIsOpenAPIFileSysl(t *testing.T) {
 	t.Parallel()
 	sourceContext := &sysl.SourceContext{File: "github.com/myorg/test/spec.sysl"}
@@ -37,7 +44,7 @@ func TestIsOpenAPIFileEmpty(t *testing.T) {
 
 func TestBuildSpecURL(t *testing.T) {
 	t.Parallel()
-	expected := "https://raw.githubusercontent.com/anz-bank/sysl-catalog/master/pkg/catalog/test/simple.yaml"
+	expected := "/pkg/catalog/test/simple.yaml"
 	url, _ := BuildSpecURL(&sysl.SourceContext{File: "pkg/catalog/test/simple.yaml"})
 	assert.Equal(t, expected, url)
 }


### PR DESCRIPTION
Modifies Redoc to reference the specification file (and assumes it has been copied to the output directory). 

This requires copying of all imported specifications into the output directory. 
e.g Lets say you have a root.sysl file that imports specifications inside of a folder called `sysl`
The `sysl` folder needs to be copied to the output directory, so that the redoc page can reference the spec directly via `/sysl/targetspec.yaml`

## Checklist:
- [x] Added tests
- [ ] Updated documentation