### PR TITLE
Serve yaml, sysl and json files in server mode

### DIFF
--- a/pkg/catalog/diagram_test.go
+++ b/pkg/catalog/diagram_test.go
@@ -225,7 +225,7 @@ func TestCreateReturnDataModelWithEmpty(t *testing.T) {
 }
 func TestCreateRedoc(t *testing.T) {
 	appName := "myAppName"
-	fileName := "sysl/myfile.yaml"
+	fileName := "/sysl/myfile.yaml"
 	sourceContext := &sysl.SourceContext{File: fileName}
 	gen := Generator{
 		CurrentDir:         "myAppName",

--- a/pkg/catalog/server.go
+++ b/pkg/catalog/server.go
@@ -115,6 +115,13 @@ func (p *Generator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			p.Log.Info(err)
 		}
 		return
+	case ".yaml", ".json", ".sysl":
+		bytes, err = afero.ReadFile(afero.NewOsFs(), strings.TrimPrefix(request, "/"))
+		if err != nil {
+			p.Log.Error(err)
+			return
+		}
+		return
 	case "":
 		request += "index.html"
 	}

--- a/pkg/catalog/spec.go
+++ b/pkg/catalog/spec.go
@@ -22,7 +22,9 @@ func IsOpenAPIFile(source *sysl.SourceContext) bool {
 // BuildSpecURL takes a source context reference and builds an raw git URL for it
 // It handles sourceContext paths which are from remote repos as well as in the same repo
 func BuildSpecURL(source *sysl.SourceContext) (string, error) {
-	return "/" + source.GetFile(), nil
+	filePath := source.GetFile()
+	filePath = strings.TrimPrefix(filePath, ".")
+	return filePath, nil
 }
 
 // GetRemoteFromGit gets the URL to the git remote

--- a/pkg/catalog/spec_test.go
+++ b/pkg/catalog/spec_test.go
@@ -45,7 +45,14 @@ func TestIsOpenAPIFileEmpty(t *testing.T) {
 func TestBuildSpecURL(t *testing.T) {
 	t.Parallel()
 	expected := "/pkg/catalog/test/simple.yaml"
-	url, _ := BuildSpecURL(&sysl.SourceContext{File: "pkg/catalog/test/simple.yaml"})
+	url, _ := BuildSpecURL(&sysl.SourceContext{File: "./pkg/catalog/test/simple.yaml"})
+	assert.Equal(t, expected, url)
+}
+
+func TestBuildSpecURLNoDot(t *testing.T) {
+	t.Parallel()
+	expected := "/pkg/catalog/test/simple.yaml"
+	url, _ := BuildSpecURL(&sysl.SourceContext{File: "/pkg/catalog/test/simple.yaml"})
 	assert.Equal(t, expected, url)
 }
 


### PR DESCRIPTION
Minor change to enable `.yaml`, `.json` and `.sysl` files to be served in server mode

This is only a temporary workaround as the future plan is to generate static file and recommend a web server such Nginx


## Checklist:
- [ ] Added tests
- [ ] Updated documentation