### PR TITLE
Copy spec files to output folder

### DIFF
--- a/pkg/catalog/generator.go
+++ b/pkg/catalog/generator.go
@@ -286,6 +286,10 @@ func (p *Generator) Run() {
 	}
 
 	wg.Wait()
+	err := CopySyslModCache(p.OutputDir)
+	if err != nil {
+		logrus.Warn(err)
+	}
 }
 
 // GetFuncMap returns the funcs that are used in diagram generation.

--- a/pkg/catalog/redoc.go
+++ b/pkg/catalog/redoc.go
@@ -27,7 +27,7 @@ const RedocPage = `<!DOCTYPE html>
     </style>
   </head>
   <body>
-    <redoc spec-url='https://cors-anywhere.herokuapp.com/{{.SpecURL}}'></redoc>
+    <redoc spec-url='{{.SpecURL}}'></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
 </html>

--- a/pkg/catalog/redoc_test.go
+++ b/pkg/catalog/redoc_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestBuildRedoc(t *testing.T) {
 	url := "http://petstore.swagger.io/v2/swagger.json"
-	expectedTag := fmt.Sprintf("<redoc spec-url='https://cors-anywhere.herokuapp.com/%s'></redoc>", url)
+	expectedTag := fmt.Sprintf("<redoc spec-url='%s'></redoc>", url)
 	redoc := BuildRedoc(url)
 	assert.True(t, strings.Contains(string(redoc), expectedTag))
 }


### PR DESCRIPTION
This PR changes the way Redoc imports specifications back to copying the specification files to the output folder, so that it works with private Github repositories. In the previous change, a CORS proxy does enable the specification file to be accessed by the generated Redoc page but only for Public repositories

Reverts the following commits:

https://github.com/anz-bank/sysl-catalog/pull/189/commits/9d98469d716f45eb839c5db3dde02f5a98757dc6
https://github.com/anz-bank/sysl-catalog/pull/189/commits/987eb5d627e2bb0207793bbb7f8efdb77f66ef9d

## Checklist:
- [x] Added tests
- [x] Updated documentation