### PR TITLE
Append SourceContext version to specURL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/antlr/antlr4 v0.0.0-20200712162734-eb1adaa8a7a6 // indirect
 	github.com/anz-bank/mermaid-go v0.1.1
 	github.com/anz-bank/protoc-gen-sysl v0.0.17
-	github.com/anz-bank/sysl v0.179.0
+	github.com/anz-bank/sysl v0.180.0
 	github.com/cheggaaa/pb/v3 v3.0.4
 	github.com/getkin/kin-openapi v0.18.0 // indirect
 	github.com/gohugoio/hugo v0.74.1

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/anz-bank/sysl v0.93.0/go.mod h1:NVHgDqSHotzbNmVG/x0DB1nGFswB9MKVv0Oa5
 github.com/anz-bank/sysl v0.94.0/go.mod h1:75Wt6P08jkIy1ecDY6UO5RdCy+dE/Z8XBeO5V5Iq+2c=
 github.com/anz-bank/sysl v0.179.0 h1:NM8WSXoSjO1GCaKgqeepYiCNg62YbyXTWOe7irrl7cI=
 github.com/anz-bank/sysl v0.179.0/go.mod h1:1IRCnjxV/tyk7/qqg4uVoxGi+AQfi2xXI6aqz4yHbWY=
+github.com/anz-bank/sysl v0.180.0 h1:SKqrXxtzBVYrSFAlETVeSewvGtqMnEg+L0rgImZjfAo=
+github.com/anz-bank/sysl v0.180.0/go.mod h1:1IRCnjxV/tyk7/qqg4uVoxGi+AQfi2xXI6aqz4yHbWY=
 github.com/anz-bank/sysl-catalog v1.2.30/go.mod h1:ctu4d6a7J3WzvfaatkpANwYBTRsdS9kM3/+RxVJ/kZs=
 github.com/anz-bank/sysl-catalog v1.4.20/go.mod h1:QeUCcG4RTf/065hLAt2btwXll+OcmMyaD/jYtSwFL6A=
 github.com/anz-bank/sysl-catalog v1.4.22/go.mod h1:ygwrUMDRRmzV7F86Z/9oj6I2XnFmQV9kMruLe+Na4a8=

--- a/pkg/catalog/spec.go
+++ b/pkg/catalog/spec.go
@@ -38,7 +38,16 @@ func IsOpenAPIFile(source *sysl.SourceContext) bool {
 // BuildSpecURL takes a source context reference and builds an raw git URL for it
 // It handles sourceContext paths which are from remote repos as well as in the same repo
 func BuildSpecURL(source *sysl.SourceContext) (string, error) {
-	filePath := source.GetFile()
+	// Append the version tag to the repo name
+	var filePath string = source.GetFile()
+	if source.GetVersion() != "" {
+		names := strings.FieldsFunc(source.GetFile(), func(c rune) bool {
+			return c == '/'
+		})
+		names[2] = names[2] + "@" + source.GetVersion()
+		filePath = path.Join(names...)
+	}
+
 	filePath = strings.TrimPrefix(filePath, ".")
 	if !strings.HasPrefix(filePath, "/") {
 		filePath = "/" + filePath

--- a/pkg/catalog/spec.go
+++ b/pkg/catalog/spec.go
@@ -40,12 +40,8 @@ func IsOpenAPIFile(source *sysl.SourceContext) bool {
 func BuildSpecURL(source *sysl.SourceContext) (string, error) {
 	// Append the version tag to the repo name
 	var filePath string = source.GetFile()
-	if source.GetVersion() != "" {
-		names := strings.FieldsFunc(source.GetFile(), func(c rune) bool {
-			return c == '/'
-		})
-		names[2] = names[2] + "@" + source.GetVersion()
-		filePath = path.Join(names...)
+	if v := source.GetVersion(); v != "" {
+		filePath = AppendVersion(filePath, v)
 	}
 
 	filePath = strings.TrimPrefix(filePath, ".")
@@ -53,6 +49,19 @@ func BuildSpecURL(source *sysl.SourceContext) (string, error) {
 		filePath = "/" + filePath
 	}
 	return filePath, nil
+}
+
+// AppendVersion takes in a remote file import path and a version, and appends the version tag to the repo name separated by the '@' char
+// e.g for an input
+// - remoteFilePath github.com/anz-bank/sysl-examples/demos/grocerystore/grocerystore.sysl
+// - version v0.0.0-c63b9e92813a
+// it returns /github.com/anz-bank/sysl-examples@v0.0.0-c63b9e92813a/demos/grocerystore/grocerystore.sysl
+func AppendVersion(remoteFilePath string, version string) string {
+	names := strings.FieldsFunc(remoteFilePath, func(c rune) bool {
+		return c == '/'
+	})
+	names[2] = names[2] + "@" + version
+	return path.Join(names...)
 }
 
 // GetRemoteFromGit gets the URL to the git remote

--- a/pkg/catalog/spec_test.go
+++ b/pkg/catalog/spec_test.go
@@ -55,6 +55,7 @@ func TestBuildSpecURL(t *testing.T) {
 		{"Simple", args{source: &sysl.SourceContext{File: "./pkg/catalog/test/simple.yaml"}}, "/pkg/catalog/test/simple.yaml", false},
 		{"NoDot", args{source: &sysl.SourceContext{File: "/pkg/catalog/test/simple.yaml"}}, "/pkg/catalog/test/simple.yaml", false},
 		{"AppendForwardSlash", args{source: &sysl.SourceContext{File: "pkg/catalog/test/simple.yaml"}}, "/pkg/catalog/test/simple.yaml", false},
+		{"AppendVersion", args{source: &sysl.SourceContext{File: "github.com/anz-bank/sysl-examples/demos/grocerystore/grocerystore.sysl", Version: "v0.0.0-c63b9e92813a"}}, "/github.com/anz-bank/sysl-examples@v0.0.0-c63b9e92813a/demos/grocerystore/grocerystore.sysl", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes an issue where Redoc views of OpenAPI specs referenced incorrect URLs

## Checklist:
- [x] Added tests
- [x] Updated documentation