### PR TITLE
Amend deployment preview to run on PR

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,6 @@
 name: Publish Deployment Preview
 
-on:
-  pull_request:
-    types: ['synchronize']
+on: [pull_request]
 
 jobs:
   publish:


### PR DESCRIPTION
Minor fix to get Deployment Preview to run more consistently on PR updates. Sometimes it wouldn't run when the PR is first opened, and only when new commits are pushed

