### PR TITLE
Jack/fix build issue

### DIFF
--- a/pkg/catalog/generator.go
+++ b/pkg/catalog/generator.go
@@ -221,7 +221,7 @@ func (p *Generator) SetOptions(
 	return p
 }
 
-var maxCreatorCount = 80
+var maxCreatorCount = 20
 var maxCreators = make(chan struct{}, maxCreatorCount)
 
 // Run Executes a project and generates markdown and diagrams to a given filesystem.

--- a/pkg/catalog/generator.go
+++ b/pkg/catalog/generator.go
@@ -264,12 +264,8 @@ func (p *Generator) Run() {
 
 	if p.Mermaid {
 		progress = pb.Full.Start(len(p.MermaidFilesToCreate))
-		start := time.Now()
 		mermaidGen := MakeMermaidGenerator()
 		diagramCreator(p.MermaidFilesToCreate, mermaidGen.GenerateAndWriteMermaidDiagram, progress)
-		wg.Wait()
-		elapsed := time.Since(start)
-		fmt.Println("Generating took ", elapsed)
 	} else {
 		if strings.Contains(p.PlantumlService, ".jar") {
 			if !p.Server {


### PR DESCRIPTION
Small change to attempt to fix an issue with running sysl-catalog in CI

Drops maxCreatorCount to 20 so that only 20 concurrent GoRoutines can run at once (which limits the amount of resource consumption by chromium, which is used to generate mermaid diagrams.)


## Checklist:
- [x] Added tests
- [x] Updated documentation