### PR TITLE
Jack/redoc without import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,9 @@ require (
 	github.com/anz-bank/mermaid-go v0.1.1
 	github.com/anz-bank/protoc-gen-sysl v0.0.17
 	github.com/anz-bank/sysl v0.180.0
+	github.com/anz-bank/sysl-examples v0.0.2 // indirect
 	github.com/cheggaaa/pb/v3 v3.0.4
+	github.com/cuminandpaprika/syslmod v0.0.0-20200820080614-3db1c953643b // indirect
 	github.com/getkin/kin-openapi v0.18.0 // indirect
 	github.com/gohugoio/hugo v0.74.1
 	github.com/hashicorp/go-retryablehttp v0.6.6

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/anz-bank/sysl v0.180.0/go.mod h1:1IRCnjxV/tyk7/qqg4uVoxGi+AQfi2xXI6aq
 github.com/anz-bank/sysl-catalog v1.2.30/go.mod h1:ctu4d6a7J3WzvfaatkpANwYBTRsdS9kM3/+RxVJ/kZs=
 github.com/anz-bank/sysl-catalog v1.4.20/go.mod h1:QeUCcG4RTf/065hLAt2btwXll+OcmMyaD/jYtSwFL6A=
 github.com/anz-bank/sysl-catalog v1.4.22/go.mod h1:ygwrUMDRRmzV7F86Z/9oj6I2XnFmQV9kMruLe+Na4a8=
+github.com/anz-bank/sysl-examples v0.0.2 h1:szNx6secul+G1tyQaWTMKXTD2YByJ/ln2V85O34IhZk=
+github.com/anz-bank/sysl-examples v0.0.2/go.mod h1:AdokLChJxixvIBlAByw+kI13pAKawobfpcYCyPssvLQ=
 github.com/anz-bank/sysl-go v0.0.0-20200325045908-46c4ce0a2736 h1:zTsCdjeUtEFYnLxSEEHAhblYzpbVRUh1a4DH0jDNDoU=
 github.com/anz-bank/sysl-go v0.0.0-20200325045908-46c4ce0a2736/go.mod h1:Jvn9Prqi9lVOaDTTPaU84If2C8MUcB7gOKOtQWqD/Hc=
 github.com/apache/thrift v0.12.0 h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=
@@ -274,6 +276,8 @@ github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cuminandpaprika/syslmod v0.0.0-20200820080614-3db1c953643b h1:7NekJJOkhAtUOC7dHBhOA8WyzbtyL1dCEN7AiH6k4X8=
+github.com/cuminandpaprika/syslmod v0.0.0-20200820080614-3db1c953643b/go.mod h1:IHw9JZUtnZCZQ7TLLSEmHhHnUG2I4Ip7IrePpZ0pROA=
 github.com/daaku/go.zipexe v1.0.0 h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY=
 github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
 github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=

--- a/pkg/catalog/generator.go
+++ b/pkg/catalog/generator.go
@@ -53,13 +53,14 @@ type Generator struct {
 	StartTemplateIndex   int
 	FilterPackage        []string // Filter these regex terms out of packagenames
 
-	CustomTemplate bool
-	LiveReload     bool // Add live reload javascript to html
-	ImageTags      bool // embedded plantuml img tags, or generated svgs
-	DisableCss     bool // used for rendering raw markdown
-	DisableImages  bool // used for omitting image creation
-	Mermaid        bool
-	Redoc          bool // used for generating redoc for openapi specs
+	CustomTemplate    bool
+	LiveReload        bool // Add live reload javascript to html
+	ImageTags         bool // embedded plantuml img tags, or generated svgs
+	DisableCss        bool // used for rendering raw markdown
+	DisableImages     bool // used for omitting image creation
+	Mermaid           bool
+	Redoc             bool // used for generating redoc for openapi specs
+	CopySpecsToOutput bool
 
 	Log  *logrus.Logger
 	Fs   afero.Fs
@@ -163,6 +164,7 @@ func NewProject(
 		GeneratedFiles:       make(map[string][]byte),
 		RedocFilesToCreate:   make(map[string]string),
 		MermaidFilesToCreate: make(map[string]string),
+		CopySpecsToOutput:    true,
 		Fs:                   fs,
 		Ext:                  ".svg",
 	}
@@ -296,9 +298,11 @@ func (p *Generator) Run() {
 	}
 
 	wg.Wait()
-	err := CopySyslModCache(p.OutputDir)
-	if err != nil {
-		logrus.Warn(err)
+	if p.CopySpecsToOutput {
+		err := CopySyslModCache(p.OutputDir)
+		if err != nil {
+			logrus.Warn(err)
+		}
 	}
 }
 

--- a/pkg/catalog/generator.go
+++ b/pkg/catalog/generator.go
@@ -89,10 +89,7 @@ func (p *Generator) SourcePath(a SourceCoder) string {
 	// 	return rootDirectory(path.Join(p.OutputDir, p.CurrentDir)) + Attribute(a, "source_path")
 	// }
 	// sourcePath, err := handleSourceURL(a.GetSourceContext().File)
-	str, err := BuildSpecURL(a.GetSourceContext())
-	if err != nil {
-		p.Log.Error(err)
-	}
+	str := BuildSpecURL(a.GetSourceContext().GetFile(), a.GetSourceContext().GetVersion())
 	return str
 }
 

--- a/pkg/catalog/generator_test.go
+++ b/pkg/catalog/generator_test.go
@@ -93,6 +93,7 @@ func TestGenerateDocsWithRedoc(t *testing.T) {
 	}
 	p := NewProject(filePath, plantumlService, "markdown", logger, m, fs, outputDir)
 	p.SetOptions(false, false, false, true, false, "", "")
+	p.CopySpecsToOutput = false
 	p.Run()
 	// Assert the right files exist
 	testFile := outputDir + "/Simple/simple.redoc.html"
@@ -147,6 +148,7 @@ whatever:
 	}
 	p := NewProject("", plantumlService, "markdown", logger, m, fs, outputDir)
 	p.SetOptions(false, false, false, true, false, "", "")
+	p.CopySpecsToOutput = false
 	p.Run()
 	// Assert the right files exist
 	testFile := outputDir + "/renamed/README.md"

--- a/pkg/catalog/spec.go
+++ b/pkg/catalog/spec.go
@@ -46,8 +46,8 @@ func GetImportPathAndVersion(app *sysl.Application) (importPath string, version 
 		importPath = specURL.GetS()
 		version = remoteFileMod.Version
 	} else {
-		importPath = app.SourceContext.File
-		version = app.SourceContext.Version
+		importPath = app.SourceContext.GetFile()
+		version = app.SourceContext.GetVersion()
 	}
 	return importPath, version, nil
 }

--- a/pkg/catalog/spec_test.go
+++ b/pkg/catalog/spec_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert"
+	"github.com/anz-bank/sysl/pkg/mod"
+	"github.com/anz-bank/sysl/pkg/sysl"
 )
 
 func TestIsOpenAPIFile(t *testing.T) {
@@ -55,6 +57,24 @@ func TestBuildSpecURL(t *testing.T) {
 	}
 }
 
+// Note this test might require SYSL_GITHUB_TOKEN to be set
+func TestGetImportPathAndVersion(t *testing.T) {
+	mod.GitHubMode = true
+	importPath := "github.com/cuminandpaprika/syslmod/specs/brokenOpenAPI.yaml"
+	attrs := map[string]*sysl.Attribute{
+		"redoc-spec": {
+			Attribute: &sysl.Attribute_S{
+				S: importPath,
+			},
+		},
+	}
+	app := &sysl.Application{Attrs: attrs}
+	result, ver, err := GetImportPathAndVersion(app)
+	assert.NoError(t, err)
+	assert.Equal(t, importPath, result)
+	assert.Equal(t, "v0.0.0-3db1c953643b", ver)
+
+}
 func TestStripExtensionSSH(t *testing.T) {
 	t.Parallel()
 	url := "https://github.com/anz-bank/sysl-catalog.git"

--- a/pkg/catalog/spec_test.go
+++ b/pkg/catalog/spec_test.go
@@ -4,47 +4,35 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert"
-	"github.com/anz-bank/sysl/pkg/sysl"
 )
 
-func TestIsOpenAPIFileJSON(t *testing.T) {
-	t.Parallel()
-	sourceContext := &sysl.SourceContext{File: "github.com/myorg/test/spec.json"}
-	result := IsOpenAPIFile(sourceContext)
-	assert.True(t, result)
-}
-
-func TestIsOpenAPIFileYAML(t *testing.T) {
-	t.Parallel()
-	sourceContext := &sysl.SourceContext{File: "github.com/myorg/test/spec.yaml"}
-	result := IsOpenAPIFile(sourceContext)
-	assert.True(t, result)
-}
-
-func TestIsOpenAPIFileYAMLOAS(t *testing.T) {
-	t.Parallel()
-	sourceContext := &sysl.SourceContext{File: "github.com/myorg/test/spec.oas.yaml"}
-	result := IsOpenAPIFile(sourceContext)
-	assert.True(t, result)
-}
-
-func TestIsOpenAPIFileSysl(t *testing.T) {
-	t.Parallel()
-	sourceContext := &sysl.SourceContext{File: "github.com/myorg/test/spec.sysl"}
-	result := IsOpenAPIFile(sourceContext)
-	assert.False(t, result)
-}
-
-func TestIsOpenAPIFileEmpty(t *testing.T) {
-	t.Parallel()
-	sourceContext := &sysl.SourceContext{}
-	result := IsOpenAPIFile(sourceContext)
-	assert.False(t, result)
+func TestIsOpenAPIFile(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want bool
+	}{
+		{"Handles empty string", "", false},
+		{"Handles .sysl", "github.com/myorg/test/spec.sysl", false},
+		{"Handles .oas.yaml", "github.com/myorg/test/spec.oas.yaml", true},
+		{"Handles .yaml", "github.com/myorg/test/spec.yaml", true},
+		{"Handles .yml", "github.com/myorg/test/spec.yml", true},
+		{"Handles .json", "github.com/myorg/test/spec.json", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsOpenAPIFile(tt.arg)
+			if got != tt.want {
+				t.Errorf("IsOpenAPIFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestBuildSpecURL(t *testing.T) {
 	type args struct {
-		source *sysl.SourceContext
+		filePath string
+		version  string
 	}
 	tests := []struct {
 		name    string
@@ -52,18 +40,14 @@ func TestBuildSpecURL(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"Simple", args{source: &sysl.SourceContext{File: "./pkg/catalog/test/simple.yaml"}}, "/pkg/catalog/test/simple.yaml", false},
-		{"NoDot", args{source: &sysl.SourceContext{File: "/pkg/catalog/test/simple.yaml"}}, "/pkg/catalog/test/simple.yaml", false},
-		{"AppendForwardSlash", args{source: &sysl.SourceContext{File: "pkg/catalog/test/simple.yaml"}}, "/pkg/catalog/test/simple.yaml", false},
-		{"AppendVersion", args{source: &sysl.SourceContext{File: "github.com/anz-bank/sysl-examples/demos/grocerystore/grocerystore.sysl", Version: "v0.0.0-c63b9e92813a"}}, "/github.com/anz-bank/sysl-examples@v0.0.0-c63b9e92813a/demos/grocerystore/grocerystore.sysl", false},
+		{"Simple", args{filePath: "./pkg/catalog/test/simple.yaml"}, "/pkg/catalog/test/simple.yaml", false},
+		{"NoDot", args{filePath: "/pkg/catalog/test/simple.yaml"}, "/pkg/catalog/test/simple.yaml", false},
+		{"AppendForwardSlash", args{filePath: "pkg/catalog/test/simple.yaml"}, "/pkg/catalog/test/simple.yaml", false},
+		{"AppendVersion", args{filePath: "github.com/anz-bank/sysl-examples/demos/grocerystore/grocerystore.sysl", version: "v0.0.0-c63b9e92813a"}, "/github.com/anz-bank/sysl-examples@v0.0.0-c63b9e92813a/demos/grocerystore/grocerystore.sysl", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := BuildSpecURL(tt.args.source)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("BuildSpecURL() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got := BuildSpecURL(tt.args.filePath, tt.args.version)
 			if got != tt.want {
 				t.Errorf("BuildSpecURL() = %v, want %v", got, tt.want)
 			}

--- a/pkg/catalog/template.go
+++ b/pkg/catalog/template.go
@@ -112,8 +112,8 @@ const NewPackageTemplate = `
 
 {{ServiceMetadata $app}}
 
-{{with CreateRedoc $app.SourceContext $appName}}
-[View OpenAPI Specs in Redoc]({{CreateRedoc $app.SourceContext $appName}})
+{{with CreateRedoc $app $appName}}
+[View OpenAPI Specs in Redoc]({{CreateRedoc $app $appName}})
 {{end}}
 
 {{range $e := $app.Endpoints}}


### PR DESCRIPTION
This PR adds the ability to add an OpenAPI specification to the catalog without needing it to be successfully imported by the Sysl OpenAPI Importer. This is a workaround to allow us to improve our ability to consume specifications whilst we fix some of the issues with the OpenAPI importer.

## Changes
- Allows the import of OpenAPI specification files via the `@redoc-spec` attribute
- Disables copying of sysl modules cache to output for tests

## Checklist:
- [x] Added tests
- [ ] Updated documentation